### PR TITLE
Fix wrangler deploy: switch from Pages config to Workers Assets

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,5 @@
 name = "tonyjmartinez-portfolio"
-pages_build_output_dir = "dist"
 compatibility_date = "2025-01-01"
+
+[assets]
+directory = "./dist"


### PR DESCRIPTION
Replaced pages_build_output_dir with [assets] directory config so that
npx wrangler deploy works correctly instead of failing with
"Missing entry-point to Worker script or to assets directory".

https://claude.ai/code/session_01UB2oapPfc6oSkhWaqSbkC9